### PR TITLE
[Feature-0512](#49) - schedule - 부서별 일정 삭제

### DIFF
--- a/src/apis/Api.js
+++ b/src/apis/Api.js
@@ -2,9 +2,6 @@ import axios from 'axios';
 const DOMAIN = 'http://localhost:8080';
 
 
-
-
-
 export const request = async (method, url, data) => {
     try {
         // API 요청
@@ -16,8 +13,7 @@ export const request = async (method, url, data) => {
             headers: {
 
                 'Authorization': `Bearer ${token}`,
-                'Content-Type': 'multipart/form-data' // 추가
-
+                // 'Content-Type': 'multipart/form-data' // 추가
             }
         });
         return response.data;

--- a/src/apis/ScheduleAPICalls.js
+++ b/src/apis/ScheduleAPICalls.js
@@ -27,6 +27,9 @@ export const insertScheduleAPI = async (newScheduleData) => {
 };
 
 export const updateScheduleAPI = async (skdNo, updatedScheduleData) => {
+  console.log("업데이트할 일정 번호:", skdNo);
+  console.log("업데이트할 일정 데이터:", updatedScheduleData);
+
   try {
     const response = await request('put', `/schedules/schedules/${skdNo}`, updatedScheduleData);
     return response;

--- a/src/components/form/ScheduleDetail.js
+++ b/src/components/form/ScheduleDetail.js
@@ -1,13 +1,24 @@
-import { Box, Grid, Typography, Button, Alert, TextField } from "@mui/material";
+import { Box, Grid, Typography, Button, Dialog, TextField } from "@mui/material";
 import moment from "moment";
 import CircularProgress from '@mui/material/CircularProgress';
 import { useState } from "react";
-import { Person } from "@mui/icons-material";
 
 export default function ScheduleDetail({ handleInputChange, scheduleDetail, closeDetailDialog, handleUpdate, handleDelete }) {
     const [updateChecked, setUpdateChecked] = useState(false);
-    const onDelete = () => { handleDelete(scheduleDetail); setUpdateChecked(false); };
-    const onUpdate = () => { handleUpdate(scheduleDetail) };
+    const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+    const handleConfirmDelete = async () => {
+        try {
+            await handleDelete(scheduleDetail);
+            setConfirmDeleteOpen(false);
+        } catch (error) {
+            console.error("일정 삭제 중 에러 발생 handleDelete: ", error);
+        }
+    };
+
+    const onCloseConfirmDelete = () => {
+        setConfirmDeleteOpen(false);
+    };
 
     if (!scheduleDetail) {
         return (
@@ -26,90 +37,84 @@ export default function ScheduleDetail({ handleInputChange, scheduleDetail, clos
                     )}
                 </Grid>
                 {updateChecked ? (
-                        <>
-                            <Grid item xs={6}>
-                                <Typography variant="body1">시작일시: </Typography>
-                            </Grid>
-                            <Grid item xs={6}>
-                                <TextField variant="outlined" name="skdStartDttm" onChange={handleInputChange} value={moment(scheduleDetail.start).format("YYYY-MM-DD HH:mm")} />
-                            </Grid>
-                            <Grid item xs={6}>
-                                <Typography variant="body1">종료일시: </Typography>
-                            </Grid>
-                            <Grid item xs={6}>
-                                <TextField variant="outlined" name="skdEndDttm" onChange={handleInputChange} value={moment(scheduleDetail.end).format("YYYY-MM-DD HH:mm")} />
-                            </Grid>
-                            <Grid item xs={6}>
-                                <Typography variant="body1">장소: </Typography>
-                            </Grid>
-                            <Grid item xs={6}>
-                                <TextField variant="outlined" name="skdLocation" onChange={handleInputChange} value={scheduleDetail.extendedProps.skdLocation} />
-                            </Grid>
-                            <Grid item xs={6}>
-                                <Typography variant="body1">메모: </Typography>
-                            </Grid>
-                            <Grid item xs={6}>
-                                <TextField variant="outlined" name="skdMemo" onChange={handleInputChange} value={scheduleDetail.extendedProps.skdMemo} />
-                            </Grid>
-                            <Grid item xs={12}>
-                                <Grid container justifyContent="flex-end" spacing={1}>
-                                    <Grid item>
-                                        {/* <Button onClick={온클릭하면 바로 컨펌창을 틀어라} variant="contained" color="error">삭제</Button> */}
-                                    </Grid>
-                                    <Grid item ml={'auto'}>
-                                        <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
-                                    </Grid>
-                                    <Grid item>
-                                        <Button onClick={() => setUpdateChecked(true)} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
-                                    </Grid>
+                    <>
+                        <Grid item xs={6}>
+                            <Typography variant="body1">시작일시: </Typography>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <TextField variant="outlined" name="skdStartDttm" onChange={handleInputChange} defaultValue={moment(scheduleDetail.start).format("YYYY-MM-DD HH:mm")} />
+                        </Grid>
+                        <Grid item xs={6}>
+                            <Typography variant="body1">종료일시: </Typography>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <TextField variant="outlined" name="skdEndDttm" onChange={handleInputChange} defaultValue={moment(scheduleDetail.end).format("YYYY-MM-DD HH:mm")} />
+                        </Grid>
+                        <Grid item xs={6}>
+                            <Typography variant="body1">장소: </Typography>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <TextField variant="outlined" name="skdLocation" onChange={handleInputChange} defaultValue={scheduleDetail.extendedProps.skdLocation} />
+                        </Grid>
+                        <Grid item xs={6}>
+                            <Typography variant="body1">메모: </Typography>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <TextField variant="outlined" name="skdMemo" onChange={handleInputChange} defaultValue={scheduleDetail.extendedProps.skdMemo} />
+                        </Grid>
+                        <Grid item xs={12}>
+                            <Grid container justifyContent="flex-end" spacing={1}>
+                                <Grid item>
+                                    <Button onClick={() => setConfirmDeleteOpen(true)} variant="contained" color="error">삭제</Button>
                                 </Grid>
-                            </Grid>
-                        </>
-                    ) : (
-                        <>
-                            <Grid item xs={6}>
-                                <Typography variant="body1">시작일시: {moment(scheduleDetail.start).format("YYYY-MM-DD HH:mm")}</Typography>
-                            </Grid>
-                            <Grid item xs={6}>
-                                <Typography variant="body1">종료일시: {moment(scheduleDetail.end).format("YYYY-MM-DD HH:mm")}</Typography>
-                            </Grid>
-                            <Grid item xs={12}>
-                                <Typography variant="body1">장소: {scheduleDetail.extendedProps.skdLocation}</Typography>
-                                <Typography variant="body1">메모: {scheduleDetail.extendedProps.skdMemo}</Typography>
-                            </Grid>
-                            <Grid item xs={12}>
-                                <Grid container justifyContent="flex-end" spacing={1}>
-                                    <Grid item>
-                                        {/* <Button onClick={온클릭하면 바로 컨펌창을 틀어라} variant="contained" color="error">삭제</Button> */}
-                                    </Grid>
-                                    <Grid item ml={'auto'}>
-                                        <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
-                                    </Grid>
-                                    <Grid item>
-                                        <Button onClick={() => setUpdateChecked(true)} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
-                                    </Grid>
+                                <Grid item ml={'auto'}>
+                                    <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
                                 </Grid>
-                            </Grid>
-                        </>
-                    )
-                }
-
-                {/* 보험용으로 가지고 있는거임 */}
-                {/* <Grid item xs={12}>
-                        <Grid container justifyContent="flex-end" spacing={1}>
-                            <Grid item>
-                                <Button onClick={onDelete} variant="contained" color="error">삭제</Button>
-                            </Grid>
-                            <Grid item ml={'auto'}>
-                                <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
-                            </Grid>
-                            <Grid item>
-                                <Button onClick={onUpdate} variant="contained" color="primary">수정</Button>
+                                <Grid item>
+                                    <Button onClick={handleUpdate} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
+                                </Grid>
                             </Grid>
                         </Grid>
-                    </Grid> */}
-
+                    </>
+                ) : (
+                    <>
+                        <Grid item xs={6}>
+                            <Typography variant="body1">시작일시: {moment(scheduleDetail.start).format("YYYY-MM-DD HH:mm")}</Typography>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <Typography variant="body1">종료일시: {moment(scheduleDetail.end).format("YYYY-MM-DD HH:mm")}</Typography>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <Typography variant="body1">장소: {scheduleDetail.extendedProps.skdLocation}</Typography>
+                            <Typography variant="body1">메모: {scheduleDetail.extendedProps.skdMemo}</Typography>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <Grid container justifyContent="flex-end" spacing={1}>
+                                <Grid item>
+                                    <Button onClick={() => setConfirmDeleteOpen(true)} variant="contained" color="error">삭제</Button>
+                                </Grid>
+                                <Grid item ml={'auto'}>
+                                    <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
+                                </Grid>
+                                <Grid item>
+                                    <Button onClick={() => setUpdateChecked(true)} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
+                                </Grid>
+                            </Grid>
+                        </Grid>
+                    </>
+                )}
             </Grid >
+
+            <Dialog open={confirmDeleteOpen} onClose={onCloseConfirmDelete}>
+                <Box p={2}>
+                    <Typography variant="body1">한 번 삭제하면 다시 복구할 수 없습니다.</Typography>
+                    <Typography variant="body1">정말로 삭제하시겠습니까?</Typography>
+                </Box>
+                <Box p={2} display="flex" justifyContent="flex-end">
+                    <Button onClick={onCloseConfirmDelete} variant="outlined" color="primary">취소</Button>
+                    <Button onClick={handleConfirmDelete} variant="contained" color="error" ml={1}>삭제</Button>
+                </Box>
+            </Dialog>
         </Box >
     );
 };

--- a/src/pages/schedules/calendar.js
+++ b/src/pages/schedules/calendar.js
@@ -17,7 +17,7 @@ const Calendar = () => {
     const [calendarReady, setCalendarReady] = useState(false);
     const [newScheduleAdded, setNewScheduleAdded] = useState(false);
     const [insertScheduleDialogOpen, setInsertScheduleDialogOpen] = useState(false);
-
+    const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
     const [detailDialogOpen, setDetailDialogOpen] = useState(false);
     const [selectedEvent, setSelectedEvent] = useState(null);
     const [scheduleDetail, setScheduleDetail] = useState(null);
@@ -57,13 +57,9 @@ const Calendar = () => {
     }, [schedules]);
 
     const onDateClickHandler = () => { setInsertScheduleDialogOpen(true); };
-
     const onInsertCancelHandler = () => { setInsertScheduleDialogOpen(false); };
-
     const openDetailDialog = () => { setDetailDialogOpen(true); };
-
     const closeDetailDialog = () => { setDetailDialogOpen(false); };
-
     const handleDateClick = () => { onDateClickHandler(); };
 
     const onEventClickHandler = (selected) => {
@@ -71,12 +67,23 @@ const Calendar = () => {
         setSelectedEvent(selected.event);
     };
 
+    const onDelete = () => { setConfirmDeleteOpen(true); };
+    const onCloseConfirmDelete = () => { setConfirmDeleteOpen(false); };
+
+    const handleConfirmDelete = async () => {
+        try {
+            await handleDelete(selectedEvent);
+            setConfirmDeleteOpen(false);
+        } catch (error) {
+            console.error("일정 삭제 중 에러 발생 handleDelete: ", error);
+        }
+    };
+
     const handleDelete = async (event) => {
         if (event) {
             try {
                 await deleteScheduleAPI(event.id);
-                alert("일정이 정상적으로 삭제되었습니다.");
-              
+
                 const token = decodeJwt(window.localStorage.getItem("accessToken"));
                 const dptNo = token.depNo;
 
@@ -86,33 +93,30 @@ const Calendar = () => {
 
             } catch (error) {
                 console.error("일정 삭제 중 에러 발생 handleDelete: ", error);
+                alert("일정 삭제에 실패했습니다.");
             }
             closeDetailDialog();
         }
     };
 
-    // 지금 버튼을 누르면 바로 이걸 호출하기로 되어있는데,  2. 수정할 데이터들을 입력받고 3. 이 handleUpdate 시켜야함.
-    const handleUpdate = async (event) => {
-        if (event) {
-            try {
-                await updateScheduleAPI(event.id);
-                alert("일정을 정상적으로 수정하였습니다. handleUpdate");
-                
-                const token = decodeJwt(window.localStorage.getItem("accessToken"));
-                const dptNo = token.depNo;
-
-                if (dptNo) {
-                    await dispatch(getScheduleAPI(dptNo));
-                }
-
-            } catch (error) {
-                console.error("일정 수정 중 에러 발생 handleUpdate: ", error);
-                alert("일정 수정에 실패했습니다.");
+    const handleUpdate = async (updatedScheduleData) => {
+        try {
+            await updateScheduleAPI(updatedScheduleData);
+            alert("일정을 정상적으로 수정하였습니다.");
+            
+            const token = decodeJwt(window.localStorage.getItem("accessToken"));
+            const dptNo = token.depNo;
+    
+            if (dptNo) {
+                await dispatch(getScheduleAPI(dptNo));
             }
-            closeDetailDialog();
+        } catch (error) {
+            console.error("일정 수정 중 에러 발생 handleUpdate: ", error);
+            alert("일정 수정에 실패했습니다.");
         }
+        closeDetailDialog();
     };
-
+    
     useEffect(() => {
         if (selectedEvent != null) {
             const skdNo = selectedEvent.id;
@@ -134,6 +138,7 @@ const Calendar = () => {
             alert("일정이 정상적으로 등록되었습니다.");
             setNewScheduleAdded(!newScheduleAdded);
         } catch (error) {
+            console.log("newScheduleData가 정말 multipartform인지??", newScheduleData);
             console.error("Error submitting schedule data:", error);
             alert("일정 등록에 실패하였습니다.");
         }
@@ -220,6 +225,7 @@ const Calendar = () => {
                     handleDelete={handleDelete}
                     handleUpdate={handleUpdate}
                     closeDetailDialog={closeDetailDialog}
+                    onCloseConfirmDelete={onCloseConfirmDelete}
                 />
             </Dialog>
         </main>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Jay-20240512-v1

### 변경 사항
기 등록 일정을 삭제하도록 컴포넌트를 생성하였습니다.

### 테스트 결과
기 등록 일정을 눌렀을때 상세조회 다이얼로그(모달)이 뜨고, 삭제를 누르면 컨펌용 다이얼로그가 뜹니다.
다시 한 번 삭제를 누르면 달력과 DB에서 모두 삭제됩니다.
정상적으로 삭제가 될 경우 자동적으로 렌더링해서 달력을 최신화하기위해 useEffect에 다시 조회하는 API를 호출합니다.
```javascript
const handleDelete = async (event) => {
        if (event) {
            try {
                await deleteScheduleAPI(event.id);

                const token = decodeJwt(window.localStorage.getItem("accessToken"));
                const dptNo = token.depNo;

                if (dptNo) {
                    await dispatch(getScheduleAPI(dptNo));
                }

            } catch (error) {
                console.error("일정 삭제 중 에러 발생 handleDelete: ", error);
                alert("일정 삭제에 실패했습니다.");
            }
            closeDetailDialog();
        }
    };
``` 
#이슈번호
#49