### PR TITLE
[Feature-0512](#51) - calender - 부서별 일정 수정

### DIFF
--- a/src/components/form/ScheduleDetail.js
+++ b/src/components/form/ScheduleDetail.js
@@ -1,11 +1,19 @@
+
+
 import { Box, Grid, Typography, Button, Dialog, TextField } from "@mui/material";
 import moment from "moment";
 import CircularProgress from '@mui/material/CircularProgress';
 import { useState } from "react";
 
-export default function ScheduleDetail({ handleInputChange, scheduleDetail, closeDetailDialog, handleUpdate, handleDelete }) {
+export default function ScheduleDetail({ inputChangeHandler, scheduleDetail, closeDetailDialog, handleUpdate, handleDelete }) {
     const [updateChecked, setUpdateChecked] = useState(false);
     const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+    const [updatedScheduleData, setUpdatedScheduleData] = useState({
+        skdStartDttm: moment(scheduleDetail?.start).format("YYYY-MM-DD HH:mm"),
+        skdEndDttm: moment(scheduleDetail?.end).format("YYYY-MM-DD HH:mm"),
+        skdLocation: scheduleDetail?.extendedProps.skdLocation,
+        skdMemo: scheduleDetail?.extendedProps.skdMemo
+    });
 
     const handleConfirmDelete = async () => {
         try {
@@ -14,6 +22,24 @@ export default function ScheduleDetail({ handleInputChange, scheduleDetail, clos
         } catch (error) {
             console.error("일정 삭제 중 에러 발생 handleDelete: ", error);
         }
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setUpdatedScheduleData({
+            ...updatedScheduleData,
+            [name]: value
+        });
+    };
+
+    const handleAction = async () => {
+        try {
+            await handleUpdate(scheduleDetail, updatedScheduleData);
+        } catch(error) {
+            console.error("일정 수정 중 에러 발생 handleUpdate: ", error);
+            alert("일정 수정에 실패했습니다.");
+        } 
+        closeDetailDialog();
     };
 
     const onCloseConfirmDelete = () => {
@@ -42,25 +68,25 @@ export default function ScheduleDetail({ handleInputChange, scheduleDetail, clos
                             <Typography variant="body1">시작일시: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField variant="outlined" name="skdStartDttm" onChange={handleInputChange} defaultValue={moment(scheduleDetail.start).format("YYYY-MM-DD HH:mm")} />
+                            <TextField variant="outlined" name="skdStartDttm" onChange={handleInputChange} value={updatedScheduleData.skdStartDttm} />
                         </Grid>
                         <Grid item xs={6}>
                             <Typography variant="body1">종료일시: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField variant="outlined" name="skdEndDttm" onChange={handleInputChange} defaultValue={moment(scheduleDetail.end).format("YYYY-MM-DD HH:mm")} />
+                            <TextField variant="outlined" name="skdEndDttm" onChange={handleInputChange} value={updatedScheduleData.skdEndDttm} />
                         </Grid>
                         <Grid item xs={6}>
                             <Typography variant="body1">장소: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField variant="outlined" name="skdLocation" onChange={handleInputChange} defaultValue={scheduleDetail.extendedProps.skdLocation} />
+                            <TextField variant="outlined" name="skdLocation" onChange={handleInputChange} value={updatedScheduleData.skdLocation} />
                         </Grid>
                         <Grid item xs={6}>
                             <Typography variant="body1">메모: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField variant="outlined" name="skdMemo" onChange={handleInputChange} defaultValue={scheduleDetail.extendedProps.skdMemo} />
+                            <TextField variant="outlined" name="skdMemo" onChange={handleInputChange} value={updatedScheduleData.skdMemo} />
                         </Grid>
                         <Grid item xs={12}>
                             <Grid container justifyContent="flex-end" spacing={1}>
@@ -71,7 +97,7 @@ export default function ScheduleDetail({ handleInputChange, scheduleDetail, clos
                                     <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
                                 </Grid>
                                 <Grid item>
-                                    <Button onClick={handleUpdate} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
+                                    <Button onClick={handleAction} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
                                 </Grid>
                             </Grid>
                         </Grid>
@@ -118,4 +144,3 @@ export default function ScheduleDetail({ handleInputChange, scheduleDetail, clos
         </Box >
     );
 };
-

--- a/src/pages/schedules/calendar.js
+++ b/src/pages/schedules/calendar.js
@@ -99,14 +99,14 @@ const Calendar = () => {
         }
     };
 
-    const handleUpdate = async (updatedScheduleData) => {
+    const handleUpdateEvent = async (selectedEvent, updatedScheduleData) => {
         try {
-            await updateScheduleAPI(updatedScheduleData);
+            await updateScheduleAPI(selectedEvent.id, updatedScheduleData);
             alert("일정을 정상적으로 수정하였습니다.");
-            
+
             const token = decodeJwt(window.localStorage.getItem("accessToken"));
             const dptNo = token.depNo;
-    
+
             if (dptNo) {
                 await dispatch(getScheduleAPI(dptNo));
             }
@@ -116,7 +116,38 @@ const Calendar = () => {
         }
         closeDetailDialog();
     };
-    
+
+    const handleUpdate = async (selectedEvent, updatedScheduleData) => {
+        if (selectedEvent && selectedEvent.event && selectedEvent.event.id) {
+
+            const eventId = selectedEvent.event.id;
+            console.log("eventId 확인", eventId);
+            if (updatedScheduleData) {
+                console.log("updatedScheduleData 확인: ", updatedScheduleData);
+            } else {
+                console.log("updatedScheduleData가 유효하지 않습니다.");
+            }
+            
+            try {
+                await updateScheduleAPI(selectedEvent.id, updatedScheduleData);
+                alert("일정을 정상적으로 수정하였습니다.");
+
+                const token = decodeJwt(window.localStorage.getItem("accessToken"));
+                const dptNo = token.depNo;
+
+                if (dptNo) {
+                    await dispatch(getScheduleAPI(dptNo));
+                }
+            } catch (error) {
+                console.error("일정 수정 중 에러 발생 handleUpdate: ", error);
+                alert("일정 수정에 실패했습니다.");
+            }
+            closeDetailDialog();
+        } else {
+            alert("event가 존재하지도 않습니다.");
+        }
+    };
+
     useEffect(() => {
         if (selectedEvent != null) {
             const skdNo = selectedEvent.id;
@@ -220,10 +251,10 @@ const Calendar = () => {
             <Dialog open={detailDialogOpen} onClose={closeDetailDialog}>
                 <DialogTitle>상세 정보</DialogTitle>
                 <ScheduleDetail
-                    handleInputChange={handleInputChange}
+                    inputChangeHandler={handleInputChange}
                     scheduleDetail={scheduleDetail}
                     handleDelete={handleDelete}
-                    handleUpdate={handleUpdate}
+                    handleUpdate={handleUpdateEvent}
                     closeDetailDialog={closeDetailDialog}
                     onCloseConfirmDelete={onCloseConfirmDelete}
                 />


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Jay-20240512-v2

### 변경 사항
부서별 일정 수정 기능을 추가하였습니다.

### 테스트 결과
부서별 일정 수정 기능이 성공적으로 작동합니다.

삼항 연산자로 수정 버튼을 눌렀을때 Typography가 아닌 TextField로 이루어진 화면을 렌더링합니다.
value가 바뀔때 handleInputChange 함수를 실행시켰으며, 바뀐 정보는 useState로 updatedScheduleData라는 이름으로 받아줍니다.
매개변수로 일정번호와 변경된 내용을 다시 캘린더로 전달했고, 캘린더에 있는 updateScheduleAPI를 호출해서 작업을 마쳤습니다.

#이슈번호
#51 