### PR TITLE
[Feature-0521](#116) - ReserveDetail - 자원예약 수정

### DIFF
--- a/src/apis/ReserveAPICalls.js
+++ b/src/apis/ReserveAPICalls.js
@@ -1,8 +1,7 @@
 import { request } from './Api';
-import { GET_RESERVE, POST_RESERVE } from '../modules/ReserveModule'
+import { DELETE_RESERVE, GET_RESERVE, POST_RESERVE } from '../modules/ReserveModule'
 
 export const getReserveAPI = (rscCategory, rsvDate) => {
-
     return async (dispatch) => {
         try {
             const reserves = await request('GET', `/reserves?category=${rscCategory}&date=${rsvDate}`);
@@ -35,5 +34,15 @@ export const updateReserveAPI = async (rsvNo, updatedReserveData) => {
     } catch (error) {
         const errorMessage = error.response ? error.response.data.message : error.message;
         throw new Error(`[ReserveAPICalls중 insertReserveAPI] 오류: ${errorMessage}`);
+    }
+};
+
+export const deleteReserveAPI = async (rsvNo) => {
+    try {
+        const response = await request('delete', `/reserves/${rsvNo}`);
+        return response;
+    } catch (error) {
+        const errorMessage = error.response ? error.response.data.message : error.message;
+        throw new Error(`[ReserveAPICalls중 deleteReserveAPI 오류 발생] : ${errorMessage}`);
     }
 };

--- a/src/apis/ScheduleAPICalls.js
+++ b/src/apis/ScheduleAPICalls.js
@@ -11,7 +11,6 @@ export const getScheduleAPI = (dptNo) => {
       });
     } catch (error) {
       const errorMessage = error.response ? error.response.data.message : error.message;
-      console.log("일정 정보 조회에 실패하였습니다.");
       throw new Error(`[ScheduleAPICalls중 getScheduleAPI] 오류: ${errorMessage}`);
     }
   };
@@ -32,7 +31,6 @@ export const updateScheduleAPI = async (skdNo, updatedScheduleData) => {
     const response = await request('put', `/schedules/schedules/${skdNo}`, updatedScheduleData);
     return response;
   } catch (error) {
-    alert("수정에 실패하였습니다. updateScheduleAPI 오류");
     const errorMessage = error.response ? error.response.data.message : error.message;
     throw new Error(`[ScheduleAPICalls중 updateScheduleAPI] 오류: ${errorMessage}`);
   }

--- a/src/components/form/DeleteReserveForm.js
+++ b/src/components/form/DeleteReserveForm.js
@@ -1,0 +1,32 @@
+import { Box, Typography, Button, DialogTitle } from "@mui/material";
+import { deleteReserveAPI } from "../../apis/ReserveAPICalls";
+
+export default function DeleteReserveForm({ onCloseDeleteConfirm, selectedReserve }) {
+    
+    console.log("selectedReserve.rsvNo???", selectedReserve.id);
+
+    const handleDelete = () => {
+        try {
+            deleteReserveAPI(selectedReserve.id);
+            alert("예약이 정상적으로 삭제되었습니다.");
+            onCloseDeleteConfirm();
+        } catch (error) {
+            console.error("예약 삭제 중 에러 발생 handleDelete", error);
+            alert("예약 삭제에 실패했습니다.");
+        }
+    };
+
+    return (
+        <>
+            <DialogTitle>예약 삭제</DialogTitle>
+            <Box p={2}>
+                <Typography variant="body1">한 번 삭제하면 다시 복구할 수 없습니다.</Typography>
+                <Typography variant="body1">정말로 삭제하시겠습니까?</Typography>
+            </Box>
+            <Box p={2} display="flex" justifyContent="flex-end">
+                <Button onClick={() => onCloseDeleteConfirm(true)} variant="outlined" color="primary">닫기</Button>
+                <Button onClick={handleDelete} variant="outlined" color="error" ml={1}>삭제</Button>
+            </Box>
+        </>
+    );
+};

--- a/src/components/form/InsertReserveForm.js
+++ b/src/components/form/InsertReserveForm.js
@@ -33,9 +33,9 @@ export default function InsertReserveForm({ onInsertCancelHandler, selectedResou
         });
     };
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
         try {
-            await insertReserveAPI(newReserveData);
+            insertReserveAPI(newReserveData);
             alert("예약이 정상적으로 등록되었습니다.");
         } catch (error) {
             console.error("예약 정보 등록하면서 오류가 발생했습니다 :", error);

--- a/src/components/form/ReserveDetail.js
+++ b/src/components/form/ReserveDetail.js
@@ -1,24 +1,25 @@
 import { Box, Grid, Typography, Button, Dialog, TextField } from "@mui/material";
 import { decodeJwt } from "../../utils/tokenUtils";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { updateReserveAPI } from "../../apis/ReserveAPICalls";
 import moment from "moment";
 
 const token = decodeJwt(window.localStorage.getItem("accessToken"));
 const reserver = token?.memberName;
 
-export default function ReserveDetail({ selectedReserve, closeDetailDialog }) {
-    console.log("selectedReserve 상세조회에서", selectedReserve);
+export default function ReserveDetail({ selectedReserve, closeDetailDialog, setOpenDeleteConfirm }) {
     const [updateChecked, setUpdateChecked] = useState(false);
     const [updatedReserveData, setUpdatedReserveData] = useState({
         rsvNo: selectedReserve.rsvNo,
         reserver: reserver,
         rsvDescr: selectedReserve.rsvDescr,
-        rsvStartDttm: moment(selectedReserve?.start).format("YYYY-MM-DDTHH:mm:ss.SSSZ"),
-        rsvEndDttm: moment(selectedReserve?.end).format("YYYY-MM-DDTHH:mm:ss.SSSZ"),
+        rsvStartDttm: moment(selectedReserve.start).format("YYYY-MM-DDTHH:mm:ss.SSSZ"),
+        rsvEndDttm: moment(selectedReserve.end).format("YYYY-MM-DDTHH:mm:ss.SSSZ"),
         resources: selectedReserve.extendedProps.resources
     });
+
     const reserveNo = selectedReserve.id;
+
     const handleInputChange = (e) => {
         const { name, value } = e.target;
         setUpdatedReserveData({
@@ -29,9 +30,8 @@ export default function ReserveDetail({ selectedReserve, closeDetailDialog }) {
 
     const handleUpdateEvent = () => {
         try {
-            console.log("reserveNo ??????????", reserveNo);
             updateReserveAPI(reserveNo, updatedReserveData);
-            alert("예약 수정에 성공하였습니다. handleUpdateEvent 메소드 호출 완료");
+            alert("예약 수정에 성공하였습니다.");
         } catch (error) {
             console.error("예약 수정 중 에러 발생 handleUpdate: ", error);
             alert("예약 수정에 실패했습니다.");
@@ -39,9 +39,21 @@ export default function ReserveDetail({ selectedReserve, closeDetailDialog }) {
         closeDetailDialog();
     };
 
-    // TODO LIST
-    // handleDelete
-    // onCloseConfirmDelete
+    // TODO LIST. 추후에 업데이트해야함. 예약자의 아이디와 사용자의 아이디의 일치여부 판별 필요함.
+    const isReserver = () => {
+        return reserver === updatedReserveData.reserver;
+    };
+
+    useEffect(() => {
+        setUpdatedReserveData({
+            rsvNo: selectedReserve.rsvNo,
+            reserver: reserver,
+            rsvDescr: selectedReserve.title,
+            rsvStartDttm: moment(selectedReserve.start).format("YYYY-MM-DDTHH:mm"),
+            rsvEndDttm: moment(selectedReserve.end).format("YYYY-MM-DDTHH:mm"),
+            resources: selectedReserve.extendedProps.resources
+        });
+    }, [selectedReserve]);
 
     return (
         <Box p={2}>
@@ -56,25 +68,25 @@ export default function ReserveDetail({ selectedReserve, closeDetailDialog }) {
                             <Typography variant="body1">예약 시작 일시: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField type="datetime-local" variant="outlined" name="rsvStartDttm" onChange={handleInputChange} value={updatedReserveData.rsvStartDttm} />
+                            <TextField type="datetime-local" variant="outlined" name="rsvStartDttm" onChange={handleInputChange} defaultValue={updatedReserveData.rsvStartDttm} />
                         </Grid>
                         <Grid item xs={6}>
                             <Typography variant="body1">예약 종료 일시: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField type="datetime-local" variant="outlined" name="rsvEndDttm" onChange={handleInputChange} value={updatedReserveData.rsvEndDttm} />
+                            <TextField type="datetime-local" variant="outlined" name="rsvEndDttm" onChange={handleInputChange} defaultValue={updatedReserveData.rsvEndDttm} />
                         </Grid>
                         <Grid item xs={6}>
                             <Typography variant="body1">사용목적: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <TextField variant="outlined" name="rsvDescr" onChange={handleInputChange} value={updatedReserveData.rsvDescr} />
+                            <TextField variant="outlined" name="rsvDescr" onChange={handleInputChange} defaultValue={updatedReserveData.rsvDescr} />
                         </Grid>
                         <Grid item xs={6}>
                             <Typography variant="body1">예약자: </Typography>
                         </Grid>
                         <Grid item xs={6}>
-                            <Typography variant="body1">{updatedReserveData.reserver}</Typography>
+                            <Typography variant="body1">{selectedReserve.extendedProps.reserver}</Typography>
                         </Grid>
                         <Grid item xs={12}>
                             <Grid container justifyContent="flex-end" spacing={1}>
@@ -101,15 +113,22 @@ export default function ReserveDetail({ selectedReserve, closeDetailDialog }) {
                         </Grid>
                         <Grid item xs={12}>
                             <Typography variant="body1">사용목적: {selectedReserve.title}</Typography>
-                            <Typography variant="body1">예약자: {updatedReserveData.reserver}</Typography>
+                            <Typography variant="body1">예약자: {selectedReserve.extendedProps.reserver}</Typography>
                         </Grid>
                         <Grid item xs={12}>
                             <Grid container justifyContent="flex-end" spacing={1}>
+                                {isReserver() ? (
+                                    <>
+                                        <Grid item>
+                                            <Button onClick={() => setUpdateChecked(true)} variant="contained" color="primary">수정</Button>
+                                        </Grid>
+                                        <Grid item>
+                                            <Button onClick={() => setOpenDeleteConfirm(true)} variant="contained" color="error">삭제</Button>
+                                        </Grid>
+                                    </>
+                                ) : null}
                                 <Grid item ml={'auto'}>
                                     <Button onClick={closeDetailDialog} variant="contained">닫기</Button>
-                                </Grid>
-                                <Grid item>
-                                    <Button onClick={() => setUpdateChecked(true)} onClose={() => setUpdateChecked(false)} variant="contained" color="primary">수정</Button>
                                 </Grid>
                             </Grid>
                         </Grid>
@@ -117,6 +136,5 @@ export default function ReserveDetail({ selectedReserve, closeDetailDialog }) {
                 )}
             </Grid >
         </Box >
-
     );
 };

--- a/src/modules/ReserveModule.js
+++ b/src/modules/ReserveModule.js
@@ -4,10 +4,12 @@ const initialState = [];
 
 export const GET_RESERVE = 'reserves/GET_RESERVE';
 export const POST_RESERVE = 'reserves/POST_RESERVE';
+export const DELETE_RESERVE = 'reserves/DELETE_RESERVE';
 
 const actions = createActions({
-    [GET_RESERVE]: () => {  },
-    [POST_RESERVE]: () => {  }
+    [GET_RESERVE]: () => { },
+    [POST_RESERVE]: () => { },
+    [DELETE_RESERVE]: (rsvNo) => ({ rsvNo })
 });
 
 const reserveReducer = handleActions(
@@ -17,6 +19,9 @@ const reserveReducer = handleActions(
         },
         [POST_RESERVE]: (state, { payload }) => {
             return payload;
+        },
+        [DELETE_RESERVE]: (state, { payload: { rsvNo } }) =>  {
+            return state.filter(reserve => reserve.id !== rsvNo);
         }
     }, initialState
 );

--- a/src/pages/reserves/Reserve.js
+++ b/src/pages/reserves/Reserve.js
@@ -12,6 +12,7 @@ import ResourceCategorySelect from "./ResourceCategorySelect";
 import ReserveDateSelect from "./ReserveDateSelect";
 import InsertReserveForm from "../../components/form/InsertReserveForm";
 import ReserveDetail from "../../components/form/ReserveDetail";
+import DeleteReserveForm from "../../components/form/DeleteReserveForm";
 
 export default function Reserve() {
     const dispatch = useDispatch();
@@ -26,6 +27,7 @@ export default function Reserve() {
     const [selectedResource, setSelectedResource] = useState({});
     const [insertReserveDialogOpen, setInsertReserveDialogOpen] = useState(false);
     const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+    const [openDeleteConfirm, setOpenDeleteConfirm] = useState(false);
 
     const onDateClickHandler = (selectInfo, resource) => {
         setSelectedResource(resource);
@@ -33,7 +35,11 @@ export default function Reserve() {
     };
 
     const onInsertCancelHandler = () => { setInsertReserveDialogOpen(false) };
-    const closeDetailDialog = () => { setDetailDialogOpen(false) };
+    const closeDetailDialog = () => { setDetailDialogOpen(false); };
+    const onCloseDeleteConfirm = () => {
+        setOpenDeleteConfirm(false);
+        setDetailDialogOpen(false);
+    };
 
     const onEventClickHandler = (selected) => {
         setSelectedReserve(selected.event);
@@ -182,6 +188,7 @@ export default function Reserve() {
                 )}
             </Box>
 
+            {/* 등록 폼 */}
             <Dialog open={insertReserveDialogOpen} onClose={onInsertCancelHandler}>
                 <InsertReserveForm
                     onInsertCancelHandler={onInsertCancelHandler}
@@ -189,9 +196,19 @@ export default function Reserve() {
                 />
             </Dialog>
 
+            {/* 상세조회 */}
             <Dialog open={detailDialogOpen} onClose={closeDetailDialog}>
                 <ReserveDetail
                     closeDetailDialog={closeDetailDialog}
+                    selectedReserve={selectedReserve}
+                    setOpenDeleteConfirm={setOpenDeleteConfirm}
+                />
+            </Dialog>
+
+            {/* 삭제 폼 */}
+            <Dialog open={openDeleteConfirm} onClose={onCloseDeleteConfirm}>
+                <DeleteReserveForm
+                    onCloseDeleteConfirm={onCloseDeleteConfirm}
                     selectedReserve={selectedReserve}
                 />
             </Dialog>

--- a/src/pages/reserves/ResourceCategorySelect.js
+++ b/src/pages/reserves/ResourceCategorySelect.js
@@ -30,7 +30,6 @@ export default function ResourceCategorySelect({ value, onChange }) {
           onChange={handleCategoryChange}
           input={<OutlinedInput />}
           MenuProps={MenuProps}
-          autoFocus
         >
           <MenuItem disabled value="">
             <em><FilterListIcon/>자원 카테고리</em>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Jay-20240521-v4

### 변경 사항
자원예약 수정 기능이 정상작동합니다.

### 테스트 결과
부모 컴포넌트에서 props로 전달받은 자원과 예약 정보를 사용하여 자식 컴포넌트인 ReserveDetail에서 화면에 보여집니다.
예약을 등록했을때 저장했던 예약자 (reserver)와 현재 로그인한 사용자의 아이디를 대조하여 일치할 경우 화면에서 수정버튼이 렌더링됩니다.
사용자가 기존 예약정보를 수정하려고 할때 초기값으로 기존 정보를 확인할 수 있도록 Textfield에게 value가 아닌 defaultValue를 주었습니다.

#이슈번호
#116 